### PR TITLE
Update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,14 @@
 {
+  "[javascript][typescript][typescriptreact][json][jsonc][yaml][github-actions-workflow]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "eslint.experimental.useFlatConfig": true,
-  "eslint.workingDirectories": [{ "mode": "auto" }]
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ]
 }

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -45,7 +45,11 @@ module.exports = {
   ignorePatterns: [
     // Ignore dotfiles
     '.*.js',
+    '.*.cjs',
+    '.*.mjs',
     '*.config.js',
+    '*.config.cjs',
+    '*.config.mjs',
     'node_modules/',
     'dist/',
     'storybook-static/',


### PR DESCRIPTION
Update VSCode settings and change ESLint `ignorePatterns` so that ESLint warning is not displayed.